### PR TITLE
audiopolicy: support extended feature in audiopolicymanager

### DIFF
--- a/services/audiopolicy/enginedefault/src/Engine.cpp
+++ b/services/audiopolicy/enginedefault/src/Engine.cpp
@@ -461,7 +461,7 @@ audio_devices_t Engine::getDeviceForStrategyInt(legacy_strategy strategy,
             // no sonification on aux digital (e.g. HDMI)
             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_AUX_DIGITAL;
         }
-        if ((device2 == AUDIO_DEVICE_NONE) &&
+        if ((device2 == AUDIO_DEVICE_NONE) && (strategy != STRATEGY_SONIFICATION) &&
                 (getForceUse(AUDIO_POLICY_FORCE_FOR_DOCK) == AUDIO_POLICY_FORCE_ANALOG_DOCK)) {
             device2 = availableOutputDevicesType & AUDIO_DEVICE_OUT_ANLG_DOCK_HEADSET;
         }

--- a/services/audiopolicy/managerdefault/AudioPolicyManager.h
+++ b/services/audiopolicy/managerdefault/AudioPolicyManager.h
@@ -509,7 +509,7 @@ protected:
          * Must be called before updateDevicesAndOutputs()
          * @param attr to be considered
          */
-        void checkOutputForAttributes(const audio_attributes_t &attr);
+        virtual void checkOutputForAttributes(const audio_attributes_t &attr);
 
         bool followsSameRouting(const audio_attributes_t &lAttr,
                                 const audio_attributes_t &rAttr) const;


### PR DESCRIPTION
This is a squashed commit of the changes added to support
extended feature in audiopolicymanager and related error.
Only some parts of the fixes have been ported as the custom
audio policy has the other required changes.

audiopolicy: support extended feature in audiopolicymanager
audiopolicy: additional change for extended feature
audiopolicy: Add voip flag to output flag list
Change-Id: I7738d4b0ac11ee6d93bfd67e2553eae8518ff719
audiopolicy: follow-up change to support extended feature
Change-Id: Iddc14a3e2e61bc57f8637eae71e36cc21ce2d3e8

CRs-Fixed: 2208307
Change-Id: Icc12395480cfe5e26bf935fb643d080990d8a4e9